### PR TITLE
Handle CommonJS module

### DIFF
--- a/packages/svelte-vega/src/lib/utils.ts
+++ b/packages/svelte-vega/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import type { View, SignalListeners } from './types';
-import { vega } from 'vega-embed';
+import pkg from 'vega-embed';
+const { vega } = pkg;
 import equal from 'fast-deep-equal';
 import type { VisualizationSpec, EmbedOptions } from 'vega-embed';
 


### PR DESCRIPTION
Fixes #868

The `vega-embed` package is not of `"type": "module"`, so it has to be imported this way.

It seems to work for me in a stripped-down version of this package using Vite 5.